### PR TITLE
revert to webkit 2.40.5

### DIFF
--- a/site.someones.Lonewolf.yml
+++ b/site.someones.Lonewolf.yml
@@ -27,8 +27,8 @@ modules:
   - name: webkit2gtk-4.0
     sources:
       - type: archive
-        url: https://webkitgtk.org/releases/webkitgtk-2.42.0.tar.xz
-        sha256: 828f95935861fae583fb8f2ae58cf64c63c178ae2b7c2d6f73070813ad64ed1b
+        url: https://webkitgtk.org/releases/webkitgtk-2.40.5.tar.xz
+        sha256: 7de051a263668621d91a61a5eb1c3771d1a7cec900043d4afef06c326c16037f
         x-checker-data:
           type: html
           url: https://webkitgtk.org/releases/


### PR DESCRIPTION
revert to webkit 2.40.5 because of https://github.com/aichingm/lonewolf/issues/2

https://bugs.webkit.org/show_bug.cgi?id=259644
